### PR TITLE
Expand usage documentation

### DIFF
--- a/src/app/docs/usage/messages/page.md
+++ b/src/app/docs/usage/messages/page.md
@@ -771,16 +771,16 @@ use DirectoryTree\ImapEngine\DraftMessage;
 
 $uid = $inbox->messages()->append(
     new DraftMessage(
-        from: = 'foo@email.com',
-        to: = 'bar@email.com',
-        subject: = 'Hello World'
-        text: = 'This is the message body.',
-        html: = '<p>This is the message body.</p>',
+        from: 'foo@email.com',
+        to: 'bar@email.com',
+        subject: 'Hello World',
+        text: 'This is the message body.',
+        html: '<p>This is the message body.</p>',
     )
 );
 ```
 
-Draft messages also accept attachments:
+Draft messages also accept attachments. Each attachment should be passed as its own item in the `attachments` array:
 
 ```php
 $inbox->messages()->append(
@@ -789,6 +789,36 @@ $inbox->messages()->append(
         attachments: [
             '/path/to/attachment.pdf',
             '/path/to/another-attachment.jpg',
+        ]
+    )
+);
+```
+
+You may also attach open resources:
+
+```php
+$resource = fopen('/path/to/report.csv', 'r');
+
+$inbox->messages()->append(
+    new DraftMessage(
+        // ...
+        attachments: [
+            $resource,
+        ]
+    )
+);
+```
+
+Existing `Attachment` objects can be attached as well. This is useful when copying an attachment from one message into a new draft:
+
+```php
+$attachments = $message->attachments(fetch: true);
+
+$inbox->messages()->append(
+    new DraftMessage(
+        // ...
+        attachments: [
+            $attachments[0],
         ]
     )
 );


### PR DESCRIPTION
## Description

Expands the usage documentation based on a source audit of ImapEngine's public APIs.

This updates the docs to:

- Document additional message search helpers, date helpers, UID searches, Message-ID searches, keyword searches, and fetch read-state behavior
- Add attachment details for `save()`, `extension()`, `contentDisposition()`, and stream-level access
- Document draft attachment inputs, including file paths, resources, and existing `Attachment` objects
- Correct the Mbox example to cast `FileMessage` to a string instead of calling a non-existent `raw()` method
- Fix the `FolderRepository` typo
- Add `Mailbox::make()`, proxy, certificate validation, and low-level connection examples
- Refresh testing docs to use inline setup, Pest examples without `$this`, and clearer fake behavior notes

## Verification

- `git diff --check`
- `npm run build`